### PR TITLE
Add endpoint override for S3 alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # konserve-s3
 
-A [S3](https://aws.amazon.com/s3) backend for [konserve](https://github.com/replikativ/konserve). 
+A backend for [konserve](https://github.com/replikativ/konserve) that supports Amazon [S3](https://aws.amazon.com/s3) and any S3-compatible storage API.
+
 
 ## Usage
 
@@ -21,6 +22,9 @@ For asynchronous execution take a look at the [konserve example](https://github.
   {:region "us-west-1"
    :bucket "konserve-demo"
    :store-id "test-store" ;; allows multiple stores per bucket
+   ;; optional: use for S3-compatible services like Tigris or MinIO
+   :endpoint-override {:protocol :https
+                       :hostname "fly.storage.tigris.dev"}
    })
 
 (def store (connect-s3-store s3-spec :opts {:sync? true}))

--- a/src/konserve_s3/core.clj
+++ b/src/konserve_s3/core.clj
@@ -42,7 +42,7 @@
 (defn common-client-config
   [client {:keys [region x-ray? access-key secret endpoint-override]}] 
   (-> client
-      (cond-> region (.region (regions (if (= region "auto") "us-east-1" region)))
+      (cond-> region (.region (if (= region "auto") (Region/of region) (regions region)))
               x-ray? (.overrideConfiguration (-> (ClientOverrideConfiguration/builder)
                                                  (.addExecutionInterceptor (TracingInterceptor.))
                                                  (.build)))


### PR DESCRIPTION
This adds support for using alternative storage with S3 compatible API's.

Some offer global endpoints. However I was not able to figure out how to add that. So if "auto" is set as a region it defaults to "us-east-1". There is probably a better way to handle this.