### PR TITLE
feat: switch to unified logging lib

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps {com.taoensso/timbre {:mvn/version "5.1.2"}
+ :deps {io.replikativ/logging {:mvn/version "0.1.3"}
         org.replikativ/konserve {:mvn/version "0.9.342"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
         org.clojure/clojure {:mvn/version "1.10.3"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps {io.replikativ/logging {:mvn/version "0.1.3"}
+ :deps {org.replikativ/logging {:mvn/version "0.1.3"}
         org.replikativ/konserve {:mvn/version "0.9.342"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
         org.clojure/clojure {:mvn/version "1.10.3"}

--- a/src/konserve_s3/core.clj
+++ b/src/konserve_s3/core.clj
@@ -5,7 +5,7 @@
             [konserve.utils :refer [async+sync *default-sync-translation*]]
             [konserve.store :as store]
             [superv.async :refer [go-try- <?-]]
-            [taoensso.timbre :refer [info trace]]
+            [replikativ.logging :as log]
             [clojure.core.async :refer [chan go]])
   (:import [java.io ByteArrayInputStream ByteArrayOutputStream]
            [java.util Arrays UUID]
@@ -229,7 +229,7 @@
            new-set
            (if (< attempt max-retries)
              (do
-               (trace "Registry update conflict, retrying..." attempt)
+               (log/trace :konserve.s3/registry-update-conflict {:attempt attempt})
                (recur (inc attempt)))
              (throw (ex-info "Registry update failed after max retries"
                              {:max-retries max-retries}))))
@@ -375,7 +375,7 @@
   (-delete-store [_ env]
     (async+sync (:sync? env) *default-sync-translation*
                 (go-try- (when (bucket-exists? client bucket)
-                           (info "This will delete all konserve files, but won't delete the bucket. You can use konserve-s3.core/delete-bucket if you intend to delete the bucket as well.")
+                           (log/info :konserve.s3/delete-store "Deleting all konserve files. Use konserve-s3.core/delete-bucket to delete the bucket.")
                            (doseq [keys (->> (list-objects client bucket)
                                              (filter (fn [^String key]
                                                        (and (.startsWith key store-id)
@@ -384,7 +384,7 @@
                                                                 (.endsWith key ".ksv.backup")
                                                                 (.endsWith key ".konserve-metadata")))))
                                              (partition deletion-batch-size deletion-batch-size []))]
-                             (trace "deleting keys: " keys)
+                             (log/trace :konserve.s3/deleting-keys {:keys keys})
                              (delete-keys client bucket keys))
                            ;; Remove store-id from registry with optimistic concurrency control
                            (let [store-uuid (UUID/fromString store-id)]


### PR DESCRIPTION
## Summary
- Replace `taoensso/timbre` with `io.replikativ/logging` (wrapping `taoensso/trove`)
- Convert all log calls to structured format with mandatory keyword IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)