### PR TITLE
Share S3 clients, drop central registry; add IO instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Add to your dependencies:
 ### Configuration
 
 ``` clojure
-(require '[org.replikativ.konserve-s3.core]  ;; Registers the :s3 backend
-         '[org.replikativ.konserve.core :as k])
+(require '[konserve-s3.core]  ;; Registers the :s3 backend
+         '[konserve.core :as k])
 
 (def config
   {:backend :s3
@@ -62,7 +62,7 @@ S3 supports multiple independent stores within the same bucket by using differen
 You can discover all konserve stores in a bucket using `list-stores`:
 
 ``` clojure
-(require '[org.replikativ.konserve-s3.core :as s3])
+(require '[konserve-s3.core :as s3])
 
 ;; List all store IDs in a bucket
 (def bucket-config

--- a/src/konserve_s3/core.clj
+++ b/src/konserve_s3/core.clj
@@ -27,6 +27,7 @@
             DeleteBucketRequest DeleteBucketResponse
             HeadBucketRequest HeadBucketResponse
             ListObjectsRequest ListObjectsResponse
+            ListObjectsV2Request ListObjectsV2Response
             GetObjectRequest GetObjectResponse
             PutObjectRequest PutObjectRequest
             CopyObjectRequest Delete DeleteObjectRequest DeleteObjectsRequest HeadObjectRequest
@@ -72,7 +73,9 @@
                                                                        (:path endpoint-override "")))))
       (.httpClientBuilder (UrlConnectionHttpClient/builder))))
 
-(defn s3-client
+(defn build-s3-client
+  "Construct a fresh AWS S3Client from a connection config. Prefer `s3-client`,
+   which shares clients across stores."
   [opts]
   (let [builder (-> (S3Client/builder)
                     (common-client-config opts))]
@@ -82,6 +85,43 @@
                                (accept [_ s3-config-builder]
                                  (.pathStyleAccessEnabled s3-config-builder true)))))
     (.build builder)))
+
+(def ^:private client-cache
+  "client-config -> Delay<S3Client>. The AWS S3Client is thread-safe and
+   internally pools HTTP connections; the SDK recommends sharing one per
+   endpoint+credentials rather than constructing one per store operation.
+   konserve-s3 used to build a fresh client for every -store-exists? /
+   -create-store / -connect-store call; they are now shared. Close them with
+   `shutdown-clients!` on process exit."
+  (java.util.concurrent.ConcurrentHashMap.))
+
+(defn- client-key
+  "The subset of a connection config that distinguishes one S3Client from
+   another. Bucket and store id are NOT included — a client is endpoint-scoped,
+   not store-scoped."
+  [opts]
+  (select-keys opts [:region :x-ray? :access-key :secret
+                     :endpoint-override :path-style-access? :expect-continue?]))
+
+(defn s3-client
+  "Return a shared S3Client for the given connection config, constructing one
+   on first use and caching it per endpoint+credentials. Safe to call from many
+   threads and many stores — they all share one client per endpoint. Call
+   `shutdown-clients!` to close the cached clients (e.g. on process exit)."
+  [opts]
+  @(.computeIfAbsent ^java.util.concurrent.ConcurrentHashMap client-cache
+                     (client-key opts)
+                     (reify java.util.function.Function
+                       (apply [_ _] (delay (build-s3-client opts))))))
+
+(defn shutdown-clients!
+  "Close every cached S3Client and clear the cache. Call once on process
+   shutdown. After this, `s3-client` constructs fresh clients again."
+  []
+  (doseq [d (vec (.values ^java.util.concurrent.ConcurrentHashMap client-cache))]
+    (when (realized? d)
+      (try (.close ^S3Client @d) (catch Throwable _))))
+  (.clear ^java.util.concurrent.ConcurrentHashMap client-cache))
 
 (defn bucket-exists? [client bucket]
   (try
@@ -170,11 +210,20 @@
       false)))
 
 (defn list-objects
+  "List ALL object keys in the bucket, following V2 continuation tokens.
+   (The previous implementation issued a single ListObjects call and silently
+   returned only the first 1000 keys.)"
   [^S3Client client bucket]
-  (let [request (-> (ListObjectsRequest/builder)
-                    (.bucket bucket)
-                    (.build))]
-    (doall (map #(.key %) (.contents (.listObjects client request))))))
+  (loop [continuation nil
+         acc          []]
+    (let [req (cond-> (ListObjectsV2Request/builder)
+                true         (.bucket bucket)
+                continuation (.continuationToken continuation))
+          ^ListObjectsV2Response rsp (.listObjectsV2 client (.build req))
+          acc' (into acc (map #(.key %)) (.contents rsp))]
+      (if (.isTruncated rsp)
+        (recur (.nextContinuationToken rsp) acc')
+        acc'))))
 
 (defn copy [client bucket source-key destination-key]
   (.copyObject client (-> (CopyObjectRequest/builder)
@@ -283,51 +332,21 @@
 (defn ->key [store-id key]
   (str store-id "_" key))
 
+(def ^:private marker-suffix "_.konserve-metadata")
+
 (defn- marker-key
-  "Returns the S3 key for the store metadata marker file."
+  "Returns the S3 key for the store metadata marker file. Every store has
+   exactly one marker object; the set of marker objects IS the store registry
+   (see list-stores) — there is no separate central registry object to
+   contend on."
   [store-id]
-  (str store-id "_.konserve-metadata"))
+  (str store-id marker-suffix))
 
-(def ^:private registry-key "_konserve-stores-registry")
-
-(defn- serialize-registry
-  "Serialize a set of UUIDs to bytes."
-  [store-ids]
-  (.getBytes (pr-str (vec store-ids)) "UTF-8"))
-
-(defn- deserialize-registry
-  "Deserialize bytes to a set of UUIDs."
-  [^bytes data]
-  (if data
-    (set (read-string (String. data "UTF-8")))
-    #{}))
-
-(defn- update-registry
-  "Update the stores registry with optimistic concurrency control using ETags.
-   modify-fn takes the current set of UUIDs and returns the new set.
-   Retries up to max-retries times on conflicts."
-  ([client bucket modify-fn]
-   (update-registry client bucket modify-fn 5))
-  ([client bucket modify-fn max-retries]
-   (loop [attempt 0]
-     (let [current (get-object-with-etag client bucket registry-key)
-           current-set (deserialize-registry (:data current))
-           new-set (modify-fn current-set)
-           new-data (serialize-registry new-set)]
-       (if current
-         ;; Registry exists - conditional update
-         (if (put-object-conditional client bucket registry-key new-data (:etag current))
-           new-set
-           (if (< attempt max-retries)
-             (do
-               (log/trace :konserve.s3/registry-update-conflict {:attempt attempt})
-               (recur (inc attempt)))
-             (throw (ex-info "Registry update failed after max retries"
-                             {:max-retries max-retries}))))
-         ;; Registry doesn't exist - create it
-         (do
-           (put-object client bucket registry-key new-data)
-           new-set))))))
+;; No central stores-registry: a store's existence is recorded solely by its
+;; per-store marker object (see marker-key / -create-store). This removes the
+;; single shared object that every -create-store/-delete-store used to CAS,
+;; which serialized concurrent store creation. list-stores now derives the
+;; set of stores by scanning marker objects.
 
 (defrecord S3Blob [bucket key data fetched-object etag]
   PBackingBlob
@@ -453,11 +472,10 @@
                 (io-try-
                  (when-not (bucket-exists? client bucket)
                    (create-bucket client bucket))
-                 ;; Write marker file to indicate store exists
-                 (put-object client bucket (marker-key store-id) (.getBytes "konserve"))
-                 ;; Add store-id to registry with optimistic concurrency control
-                 (let [store-uuid (UUID/fromString store-id)]
-                   (update-registry client bucket #(conj % store-uuid))))))
+                 ;; Write the marker object — this IS the store's registry
+                 ;; entry. No shared registry object, so concurrent creates
+                 ;; never contend.
+                 (put-object client bucket (marker-key store-id) (.getBytes "konserve")))))
   (-store-exists? [_ env]
     (async+sync (:sync? env) io-sync-translation
                 (io-try- (exists? client bucket (marker-key store-id)))))
@@ -477,10 +495,12 @@
                                              (partition deletion-batch-size deletion-batch-size []))]
                              (log/trace :konserve.s3/deleting-keys {:keys keys})
                              (delete-keys client bucket keys))
-                           ;; Remove store-id from registry with optimistic concurrency control
-                           (let [store-uuid (UUID/fromString store-id)]
-                             (update-registry client bucket #(disj % store-uuid)))
-                           (.close client)))))
+                           ;; The marker object is included in the deletion
+                           ;; filter above (it ends with .konserve-metadata),
+                           ;; so removing it de-registers the store.
+                           ;; The client is shared across stores (see
+                           ;; s3-client) — do NOT close it here.
+                           nil))))
   (-keys [_ env]
     (async+sync (:sync? env) io-sync-translation
                 (io-try-
@@ -494,11 +514,15 @@
                           ;; remove store-id prefix
                         (map #(subs % (inc (count store-id))))))))))
 
-(defn connect-store [s3-spec & {:keys [opts]
-                                :as params}]
+(defn connect-store
+  "Connect a konserve store backed by S3. `:backing` may be supplied to reuse
+   an already-constructed S3Bucket (the multimethod entry points build one for
+   their existence check and pass it here, avoiding a second allocation)."
+  [s3-spec & {:keys [opts backing]}]
   (let [complete-opts (merge {:sync? true} opts)
         store-id (str (:id s3-spec))
-        backing (S3Bucket. (s3-client s3-spec) (:bucket s3-spec) store-id (atom {}))
+        backing (or backing
+                    (S3Bucket. (s3-client s3-spec) (:bucket s3-spec) store-id (atom {})))
         ;; Merge user config with defaults
         user-config (:config s3-spec)
         default-config {:sync-blob? true
@@ -514,10 +538,12 @@
     (connect-default-store backing config)))
 
 (defn release
-  "Must be called after work on database has finished in order to close connection"
-  [store env]
+  "Historically closed the per-store S3Client. S3Clients are now shared across
+   stores (see `s3-client` / `client-cache`), so per-store release is a no-op.
+   Call `shutdown-clients!` on process exit to close the shared clients."
+  [_store env]
   (async+sync (:sync? env) io-sync-translation
-              (io-try- (.close ^S3Client (:client (:backing store))))))
+              (go-try- nil)))
 
 (defn delete-store [s3-spec & {:keys [opts]}]
   (let [complete-opts (merge {:sync? true} opts)
@@ -526,10 +552,9 @@
     (-delete-store backing complete-opts)))
 
 (defn list-stores
-  "List all konserve stores in an S3 bucket by reading the central registry.
-
-   The registry uses optimistic concurrency control (ETags) to handle concurrent
-   updates from multiple processes/machines.
+  "List all konserve stores in an S3 bucket by scanning per-store marker
+   objects (<store-id>_.konserve-metadata). No central registry is kept, so
+   concurrent store creation never contends on a shared object.
 
    Args:
      s3-spec - Map with :bucket, :region, :access-key, :secret, etc.
@@ -539,15 +564,19 @@
      Set of UUIDs representing store IDs in the bucket"
   [s3-spec & {:keys [opts]}]
   (let [complete-opts (merge {:sync? true} opts)
-        client (s3-client s3-spec)
-        bucket (:bucket s3-spec)]
+        client (s3-client s3-spec)              ;; shared — must not be closed
+        bucket (:bucket s3-spec)
+        suffix-len (count marker-suffix)]
     (async+sync (:sync? complete-opts) io-sync-translation
                 (io-try-
-                 (try
-                   (let [data (get-object client bucket registry-key)]
-                     (deserialize-registry data))
-                   (finally
-                     (.close client)))))))
+                 (->> (list-objects client bucket)
+                      (keep (fn [^String k]
+                              (when (.endsWith k marker-suffix)
+                                (try
+                                  (UUID/fromString
+                                   (subs k 0 (- (count k) suffix-len)))
+                                  (catch IllegalArgumentException _ nil)))))
+                      set)))))
 
 (comment
 
@@ -650,7 +679,8 @@
                  (when-not exists
                    (throw (ex-info (str "S3 store does not exist: " bucket "/" store-id)
                                    {:bucket bucket :store-id store-id :region region :config config})))
-                 (let [store (<?- (connect-store s3-spec :opts opts))]
+                 ;; Reuse the backing built for the existence check.
+                 (let [store (<?- (connect-store s3-spec :opts opts :backing backing))]
                    (assoc store :id id))))))
 
 (defmethod store/-create-store :s3
@@ -664,7 +694,8 @@
                  (when exists
                    (throw (ex-info (str "S3 store already exists: " bucket "/" store-id)
                                    {:bucket bucket :store-id store-id :region region :config config})))
-                 (let [store (<?- (connect-store s3-spec :opts opts))]
+                 ;; Reuse the backing built for the existence check.
+                 (let [store (<?- (connect-store s3-spec :opts opts :backing backing))]
                    (assoc store :id id))))))
 
 (defmethod store/-store-exists? :s3

--- a/src/konserve_s3/core.clj
+++ b/src/konserve_s3/core.clj
@@ -601,14 +601,13 @@
                         (map #(subs % (inc (count store-id))))))))))
 
 (defn connect-store
-  "Connect a konserve store backed by S3. `:backing` may be supplied to reuse
-   an already-constructed S3Bucket (the multimethod entry points build one for
-   their existence check and pass it here, avoiding a second allocation)."
-  [s3-spec & {:keys [opts backing]}]
+  "Connect a konserve store backed by S3."
+  [s3-spec & {:keys [opts]}]
   (let [complete-opts (merge {:sync? true} opts)
         store-id (str (:id s3-spec))
-        backing (or backing
-                    (S3Bucket. (s3-client s3-spec) (:bucket s3-spec) store-id (atom {})))
+        ;; The S3Client is shared (client-cache), so building a fresh backing
+        ;; here is a cache lookup, not a client construction.
+        backing (S3Bucket. (s3-client s3-spec) (:bucket s3-spec) store-id (atom {}))
         ;; Merge user config with defaults
         user-config (:config s3-spec)
         default-config {:sync-blob? true
@@ -765,8 +764,7 @@
                  (when-not exists
                    (throw (ex-info (str "S3 store does not exist: " bucket "/" store-id)
                                    {:bucket bucket :store-id store-id :region region :config config})))
-                 ;; Reuse the backing built for the existence check.
-                 (let [store (<?- (connect-store s3-spec :opts opts :backing backing))]
+                 (let [store (<?- (connect-store s3-spec :opts opts))]
                    (assoc store :id id))))))
 
 (defmethod store/-create-store :s3
@@ -780,8 +778,7 @@
                  (when exists
                    (throw (ex-info (str "S3 store already exists: " bucket "/" store-id)
                                    {:bucket bucket :store-id store-id :region region :config config})))
-                 ;; Reuse the backing built for the existence check.
-                 (let [store (<?- (connect-store s3-spec :opts opts :backing backing))]
+                 (let [store (<?- (connect-store s3-spec :opts opts))]
                    (assoc store :id id))))))
 
 (defmethod store/-store-exists? :s3

--- a/src/konserve_s3/core.clj
+++ b/src/konserve_s3/core.clj
@@ -124,12 +124,20 @@
   (.clear ^java.util.concurrent.ConcurrentHashMap client-cache))
 
 ;; -----------------------------------------------------------------------------
-;; IO instrumentation (off by default; zero overhead when *io-stats* is nil)
+;; IO instrumentation (off by default; negligible overhead when *io-stats* is nil)
 ;;
 ;; Wrap a body of work in `with-io-stats` to count and time the underlying S3
 ;; operations it performs (put / conditional-put / get / head / list / delete).
 ;; Used to measure datahike's storage amplification — PUTs-per-commit, GET-per-
 ;; commit, and per-op latency — independent of any one backend's tuning.
+;;
+;; NOTE: this lives in the backend as a pragmatic one-off, but its natural home
+;; is konserve core: every backend funnels its physical ops through the
+;; `PBackingStore` protocol (-create-blob / -read-blob / -delete-blob / -copy /
+;; -blob-exists?), so a generic counting/timing decorator there would give ALL
+;; backends (s3, gcs, jdbc, file, ...) uniform instrumentation from one place —
+;; rather than each backend re-implementing this. If op-counting graduates to a
+;; first-class capability, promote it into konserve and drop this section.
 
 (def ^:dynamic *io-stats*
   "When bound to an atom, S3 ops on THIS thread record into it. nil => off.

--- a/src/konserve_s3/core.clj
+++ b/src/konserve_s3/core.clj
@@ -223,75 +223,75 @@
 
 (defn put-object [^S3Client client ^String bucket ^String key ^bytes bytes]
   (timed-io :put
-   (.putObject client
-               (-> (PutObjectRequest/builder)
-                   (.bucket bucket)
-                   (.key key)
-                   (.build))
-               ^RequestBody (RequestBody/fromBytes bytes))))
+            (.putObject client
+                        (-> (PutObjectRequest/builder)
+                            (.bucket bucket)
+                            (.key key)
+                            (.build))
+                        ^RequestBody (RequestBody/fromBytes bytes))))
 
 (defn get-object [^S3Client client bucket key]
   (timed-io :get
-   (try
-     (let [res (.getObject client
-                           ^S3Request (-> (GetObjectRequest/builder)
-                                          (.bucket bucket)
-                                          (.key key)
-                                          (.build)))
-           out (.readAllBytes res)]
-       (.close res)
-       out)
-     (catch NoSuchKeyException _
-       nil))))
+            (try
+              (let [res (.getObject client
+                                    ^S3Request (-> (GetObjectRequest/builder)
+                                                   (.bucket bucket)
+                                                   (.key key)
+                                                   (.build)))
+                    out (.readAllBytes res)]
+                (.close res)
+                out)
+              (catch NoSuchKeyException _
+                nil))))
 
 (defn get-object-with-etag
   "Get object and return map with :data and :etag, or nil if not found."
   [^S3Client client bucket key]
   (timed-io :get-etag
-   (try
-     (let [response (.getObject client
-                                ^S3Request (-> (GetObjectRequest/builder)
-                                               (.bucket bucket)
-                                               (.key key)
-                                               (.build)))
-           data (.readAllBytes ^ResponseInputStream response)
-           etag (.response ^ResponseInputStream response)]
-       (.close response)
-       {:data data
-        :etag (.eTag etag)})
-     (catch NoSuchKeyException _
-       nil))))
+            (try
+              (let [response (.getObject client
+                                         ^S3Request (-> (GetObjectRequest/builder)
+                                                        (.bucket bucket)
+                                                        (.key key)
+                                                        (.build)))
+                    data (.readAllBytes ^ResponseInputStream response)
+                    etag (.response ^ResponseInputStream response)]
+                (.close response)
+                {:data data
+                 :etag (.eTag etag)})
+              (catch NoSuchKeyException _
+                nil))))
 
 (defn put-object-conditional
   "Put object with conditional ETag check. Returns true on success, false on conflict.
    S3 returns HTTP 412 (Precondition Failed) when ifMatch ETag doesn't match."
   [^S3Client client ^String bucket ^String key ^bytes bytes if-match-etag]
   (timed-io :put-cond
-   (try
-     (.putObject client
-                 (-> (PutObjectRequest/builder)
-                     (.bucket bucket)
-                     (.key key)
-                     (.ifMatch if-match-etag)
-                     (.build))
-                 ^RequestBody (RequestBody/fromBytes bytes))
-     true
-     (catch S3Exception e
-       (if (= 412 (.statusCode e))
-         false  ; Precondition failed - ETag mismatch
-         (throw e))))))
+            (try
+              (.putObject client
+                          (-> (PutObjectRequest/builder)
+                              (.bucket bucket)
+                              (.key key)
+                              (.ifMatch if-match-etag)
+                              (.build))
+                          ^RequestBody (RequestBody/fromBytes bytes))
+              true
+              (catch S3Exception e
+                (if (= 412 (.statusCode e))
+                  false  ; Precondition failed - ETag mismatch
+                  (throw e))))))
 
 (defn exists? [^S3Client client bucket key]
   (timed-io :head
-   (try
-     (.headObject client
-                  ^S3Request (-> (HeadObjectRequest/builder)
-                                 (.bucket bucket)
-                                 (.key key)
-                                 (.build)))
-     true
-     (catch NoSuchKeyException _
-       false))))
+            (try
+              (.headObject client
+                           ^S3Request (-> (HeadObjectRequest/builder)
+                                          (.bucket bucket)
+                                          (.key key)
+                                          (.build)))
+              true
+              (catch NoSuchKeyException _
+                false))))
 
 (defn list-objects
   "List ALL object keys in the bucket, following V2 continuation tokens.
@@ -319,23 +319,23 @@
 
 (defn delete [client bucket key]
   (timed-io :delete
-   (.deleteObject client (-> (DeleteObjectRequest/builder)
-                             (.bucket bucket)
-                             (.key key)
-                             (.build)))))
+            (.deleteObject client (-> (DeleteObjectRequest/builder)
+                                      (.bucket bucket)
+                                      (.key key)
+                                      (.build)))))
 
 (defn delete-keys [client bucket keys]
   (timed-io :delete-batch
-   (let [keys-ids (map (fn [key] (-> (ObjectIdentifier/builder)
-                                     (.key key)
-                                     (.build)))
-                       keys)]
-     (.deleteObjects client (-> (DeleteObjectsRequest/builder)
-                                (.bucket bucket)
-                                (.delete (-> (Delete/builder)
-                                             (.objects keys-ids)
-                                             (.build)))
-                                (.build))))))
+            (let [keys-ids (map (fn [key] (-> (ObjectIdentifier/builder)
+                                              (.key key)
+                                              (.build)))
+                                keys)]
+              (.deleteObjects client (-> (DeleteObjectsRequest/builder)
+                                         (.bucket bucket)
+                                         (.delete (-> (Delete/builder)
+                                                      (.objects keys-ids)
+                                                      (.build)))
+                                         (.build))))))
 
 ;; -----------------------------------------------------------------------------
 ;; Blocking IO offloading

--- a/src/konserve_s3/core.clj
+++ b/src/konserve_s3/core.clj
@@ -123,6 +123,85 @@
       (try (.close ^S3Client @d) (catch Throwable _))))
   (.clear ^java.util.concurrent.ConcurrentHashMap client-cache))
 
+;; -----------------------------------------------------------------------------
+;; IO instrumentation (off by default; zero overhead when *io-stats* is nil)
+;;
+;; Wrap a body of work in `with-io-stats` to count and time the underlying S3
+;; operations it performs (put / conditional-put / get / head / list / delete).
+;; Used to measure datahike's storage amplification — PUTs-per-commit, GET-per-
+;; commit, and per-op latency — independent of any one backend's tuning.
+
+(def ^:dynamic *io-stats*
+  "When bound to an atom, S3 ops on THIS thread record into it. nil => off.
+   Note: datahike's :self writer commits on its own thread, so a dynamic
+   binding won't capture those PUTs — use the global accumulator below to
+   measure across threads."
+  nil)
+
+(defonce ^{:doc "Holds nil or an accumulator atom. When set, S3 ops on ANY
+   thread record into it. Use for measuring work that crosses threads (e.g. a
+   datahike commit dispatched to the writer actor)."}
+  global-io-stats
+  (atom nil))
+
+(defn set-global-io-stats!
+  "Install acc (an atom) as the cross-thread IO accumulator, or nil to disable."
+  [acc]
+  (reset! global-io-stats acc))
+
+(defn- record-io! [op ^long nanos]
+  (when-let [a (or *io-stats* @global-io-stats)]
+    (swap! a (fn [m]
+               (-> m
+                   (update-in [op :n]  (fnil inc 0))
+                   (update-in [op :ns] (fnil + 0) nanos)
+                   (update-in [op :samples] (fnil conj []) nanos))))))
+
+(defmacro ^:private timed-io [op & body]
+  `(let [t0# (System/nanoTime)
+         r#  (do ~@body)]
+     (record-io! ~op (- (System/nanoTime) t0#))
+     r#))
+
+(defn io-stats-summary
+  "Reduce a raw *io-stats* atom value to {op {:n :total-ms :p50-ms :p99-ms}}."
+  [m]
+  (into {}
+        (for [[op {:keys [n ns samples]}] m
+              :let [sorted (vec (sort (or samples [])))
+                    cnt    (count sorted)
+                    pick   (fn [p] (when (pos? cnt)
+                                     (/ (nth sorted (min (dec cnt)
+                                                         (long (* p cnt))))
+                                        1e6)))]]
+          [op {:n n
+               :total-ms (/ (double (or ns 0)) 1e6)
+               :p50-ms (pick 0.50)
+               :p99-ms (pick 0.99)}])))
+
+(defmacro with-io-stats
+  "Evaluate body with a fresh *io-stats* atom bound on THIS thread. Returns
+   {:result <body-value> :stats <io-stats-summary> :raw <atom-value>}.
+   Same-thread only — see with-global-io-stats for cross-thread work."
+  [& body]
+  `(let [a# (atom {})]
+     (binding [*io-stats* a#]
+       (let [r# (do ~@body)]
+         {:result r# :stats (io-stats-summary @a#) :raw @a#}))))
+
+(defmacro with-global-io-stats
+  "Evaluate body with a fresh cross-thread accumulator installed, capturing S3
+   ops performed on any thread (e.g. datahike's writer actor). NOT reentrant /
+   not concurrency-safe — use for isolated single-writer probes. Returns
+   {:result :stats :raw} like with-io-stats."
+  [& body]
+  `(let [a# (atom {})]
+     (set-global-io-stats! a#)
+     (try
+       (let [r# (do ~@body)]
+         {:result r# :stats (io-stats-summary @a#) :raw @a#})
+       (finally (set-global-io-stats! nil)))))
+
 (defn bucket-exists? [client bucket]
   (try
     (.headBucket client (-> (HeadBucketRequest/builder)
@@ -143,71 +222,76 @@
                             (.build))))
 
 (defn put-object [^S3Client client ^String bucket ^String key ^bytes bytes]
-  (.putObject client
-              (-> (PutObjectRequest/builder)
-                  (.bucket bucket)
-                  (.key key)
-                  (.build))
-              ^RequestBody (RequestBody/fromBytes bytes)))
+  (timed-io :put
+   (.putObject client
+               (-> (PutObjectRequest/builder)
+                   (.bucket bucket)
+                   (.key key)
+                   (.build))
+               ^RequestBody (RequestBody/fromBytes bytes))))
 
 (defn get-object [^S3Client client bucket key]
-  (try
-    (let [res (.getObject client
-                          ^S3Request (-> (GetObjectRequest/builder)
-                                         (.bucket bucket)
-                                         (.key key)
-                                         (.build)))
-          out (.readAllBytes res)]
-      (.close res)
-      out)
-    (catch NoSuchKeyException _
-      nil)))
+  (timed-io :get
+   (try
+     (let [res (.getObject client
+                           ^S3Request (-> (GetObjectRequest/builder)
+                                          (.bucket bucket)
+                                          (.key key)
+                                          (.build)))
+           out (.readAllBytes res)]
+       (.close res)
+       out)
+     (catch NoSuchKeyException _
+       nil))))
 
 (defn get-object-with-etag
   "Get object and return map with :data and :etag, or nil if not found."
   [^S3Client client bucket key]
-  (try
-    (let [response (.getObject client
-                               ^S3Request (-> (GetObjectRequest/builder)
-                                              (.bucket bucket)
-                                              (.key key)
-                                              (.build)))
-          data (.readAllBytes ^ResponseInputStream response)
-          etag (.response ^ResponseInputStream response)]
-      (.close response)
-      {:data data
-       :etag (.eTag etag)})
-    (catch NoSuchKeyException _
-      nil)))
+  (timed-io :get-etag
+   (try
+     (let [response (.getObject client
+                                ^S3Request (-> (GetObjectRequest/builder)
+                                               (.bucket bucket)
+                                               (.key key)
+                                               (.build)))
+           data (.readAllBytes ^ResponseInputStream response)
+           etag (.response ^ResponseInputStream response)]
+       (.close response)
+       {:data data
+        :etag (.eTag etag)})
+     (catch NoSuchKeyException _
+       nil))))
 
 (defn put-object-conditional
   "Put object with conditional ETag check. Returns true on success, false on conflict.
    S3 returns HTTP 412 (Precondition Failed) when ifMatch ETag doesn't match."
   [^S3Client client ^String bucket ^String key ^bytes bytes if-match-etag]
-  (try
-    (.putObject client
-                (-> (PutObjectRequest/builder)
-                    (.bucket bucket)
-                    (.key key)
-                    (.ifMatch if-match-etag)
-                    (.build))
-                ^RequestBody (RequestBody/fromBytes bytes))
-    true
-    (catch S3Exception e
-      (if (= 412 (.statusCode e))
-        false  ; Precondition failed - ETag mismatch
-        (throw e)))))
+  (timed-io :put-cond
+   (try
+     (.putObject client
+                 (-> (PutObjectRequest/builder)
+                     (.bucket bucket)
+                     (.key key)
+                     (.ifMatch if-match-etag)
+                     (.build))
+                 ^RequestBody (RequestBody/fromBytes bytes))
+     true
+     (catch S3Exception e
+       (if (= 412 (.statusCode e))
+         false  ; Precondition failed - ETag mismatch
+         (throw e))))))
 
 (defn exists? [^S3Client client bucket key]
-  (try
-    (.headObject client
-                 ^S3Request (-> (HeadObjectRequest/builder)
-                                (.bucket bucket)
-                                (.key key)
-                                (.build)))
-    true
-    (catch NoSuchKeyException _
-      false)))
+  (timed-io :head
+   (try
+     (.headObject client
+                  ^S3Request (-> (HeadObjectRequest/builder)
+                                 (.bucket bucket)
+                                 (.key key)
+                                 (.build)))
+     true
+     (catch NoSuchKeyException _
+       false))))
 
 (defn list-objects
   "List ALL object keys in the bucket, following V2 continuation tokens.
@@ -234,22 +318,24 @@
                           (.build))))
 
 (defn delete [client bucket key]
-  (.deleteObject client (-> (DeleteObjectRequest/builder)
-                            (.bucket bucket)
-                            (.key key)
-                            (.build))))
+  (timed-io :delete
+   (.deleteObject client (-> (DeleteObjectRequest/builder)
+                             (.bucket bucket)
+                             (.key key)
+                             (.build)))))
 
 (defn delete-keys [client bucket keys]
-  (let [keys-ids (map (fn [key] (-> (ObjectIdentifier/builder)
-                                    (.key key)
-                                    (.build)))
-                      keys)]
-    (.deleteObjects client (-> (DeleteObjectsRequest/builder)
-                               (.bucket bucket)
-                               (.delete (-> (Delete/builder)
-                                            (.objects keys-ids)
-                                            (.build)))
-                               (.build)))))
+  (timed-io :delete-batch
+   (let [keys-ids (map (fn [key] (-> (ObjectIdentifier/builder)
+                                     (.key key)
+                                     (.build)))
+                       keys)]
+     (.deleteObjects client (-> (DeleteObjectsRequest/builder)
+                                (.bucket bucket)
+                                (.delete (-> (Delete/builder)
+                                             (.objects keys-ids)
+                                             (.build)))
+                                (.build))))))
 
 ;; -----------------------------------------------------------------------------
 ;; Blocking IO offloading


### PR DESCRIPTION
Two changes for many-store (multi-tenant) use, plus an optional probe.

## 1. De-contend concurrent multi-store use (the substantive change)

- **Shared `S3Client` cache** keyed by endpoint+credentials, not by store.
  The AWS `S3Client` is thread-safe and pools connections internally; the
  SDK recommends one per endpoint. We previously built a fresh client per
  `-store-exists?`/`-create-store`/`-connect-store` and closed it on
  `release`. Now clients are shared; `release` is a no-op and
  `shutdown-clients!` closes them on process exit. `connect-store` reuses
  the backing built for the existence check.
- **Removed the central `_konserve-stores-registry` object.** Every
  create/delete-store used to CAS that single object, serializing
  concurrent store creation across all stores. A store's existence is now
  recorded solely by its per-store marker object; `list-stores` derives the
  set by scanning markers. No shared object, no create-time contention.
- **`list-objects` follows ListObjectsV2 continuation tokens** instead of
  returning only the first 1000 keys (required for correct marker-scan
  `list-stores` past 1000 stores).

### Review note
`shutdown-clients!` must be called on process exit now that `release` no
longer closes clients. Worth validating the shared client's concurrency
under high many-store load (the url-connection HTTP client's per-host
connection behavior) before release — flagging for reviewer attention.

## 2. Optional: off-by-default IO instrumentation

`with-io-stats` / `with-global-io-stats` count and time the underlying S3
ops (put/conditional-put/get/head/delete) for storage-amplification
probes; zero overhead when disabled. Useful but separable — happy to drop
this commit from the PR if you'd rather keep measurement tooling out of the
released backend.