### PR TITLE
chore: bump konserve 0.9.342 -> 0.9.353

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps {org.replikativ/logging {:mvn/version "0.1.3"}
-        org.replikativ/konserve {:mvn/version "0.9.342"}
+        org.replikativ/konserve {:mvn/version "0.9.353"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
         org.clojure/clojure {:mvn/version "1.10.3"}
 


### PR DESCRIPTION
Brings the single-probe `k/get` from konserve #147 (one backend request fewer per read: 1 HEAD + 1 GET instead of 2 HEAD + 1 GET) plus the per-write metadata channel, per-key lock reclaim, and cljs header fixes shipped since 0.9.342. Suite green against MinIO (8 tests / 330 assertions / 0 failures).