### PR TITLE
fix: not-found detection resilient to reflective-invocation wrapping (breaks datahike on vthread path)

### DIFF
--- a/src/konserve_s3/core.clj
+++ b/src/konserve_s3/core.clj
@@ -238,19 +238,35 @@
                             (.build))
                         ^RequestBody (RequestBody/fromBytes bytes))))
 
+(defn- not-found?
+  "True when e (or any exception in its cause chain) signals an S3 'no such
+   key' / 404. Walks the cause chain because the SDK calls resolve reflectively
+   (S3Client is an interface; Clojure can't pick the overload for these arg
+   types), and a reflective invocation wraps the thrown NoSuchKeyException in a
+   java.lang.reflect.InvocationTargetException — which a bare
+   `(catch NoSuchKeyException ...)` misses on the virtual-thread IO path. Also
+   accepts a 404 S3Exception, which some S3-compatible servers return for HEAD
+   (no error body to derive the specific NoSuchKey code from)."
+  [^Throwable e]
+  (boolean
+   (some (fn [^Throwable c]
+           (or (instance? NoSuchKeyException c)
+               (and (instance? S3Exception c) (= 404 (.statusCode ^S3Exception c)))))
+         (take-while some? (iterate (fn [^Throwable t] (.getCause t)) e)))))
+
 (defn get-object [^S3Client client bucket key]
   (timed-io :get
             (try
               (let [res (.getObject client
-                                    ^S3Request (-> (GetObjectRequest/builder)
-                                                   (.bucket bucket)
-                                                   (.key key)
-                                                   (.build)))
+                                    ^GetObjectRequest (-> (GetObjectRequest/builder)
+                                                          (.bucket bucket)
+                                                          (.key key)
+                                                          (.build)))
                     out (.readAllBytes res)]
                 (.close res)
                 out)
-              (catch NoSuchKeyException _
-                nil))))
+              (catch Exception e
+                (if (not-found? e) nil (throw e))))))
 
 (defn get-object-with-etag
   "Get object and return map with :data and :etag, or nil if not found."
@@ -258,17 +274,17 @@
   (timed-io :get-etag
             (try
               (let [response (.getObject client
-                                         ^S3Request (-> (GetObjectRequest/builder)
-                                                        (.bucket bucket)
-                                                        (.key key)
-                                                        (.build)))
+                                         ^GetObjectRequest (-> (GetObjectRequest/builder)
+                                                               (.bucket bucket)
+                                                               (.key key)
+                                                               (.build)))
                     data (.readAllBytes ^ResponseInputStream response)
                     etag (.response ^ResponseInputStream response)]
                 (.close response)
                 {:data data
                  :etag (.eTag etag)})
-              (catch NoSuchKeyException _
-                nil))))
+              (catch Exception e
+                (if (not-found? e) nil (throw e))))))
 
 (defn put-object-conditional
   "Put object with conditional ETag check. Returns true on success, false on conflict.
@@ -293,13 +309,13 @@
   (timed-io :head
             (try
               (.headObject client
-                           ^S3Request (-> (HeadObjectRequest/builder)
-                                          (.bucket bucket)
-                                          (.key key)
-                                          (.build)))
+                           ^HeadObjectRequest (-> (HeadObjectRequest/builder)
+                                                  (.bucket bucket)
+                                                  (.key key)
+                                                  (.build)))
               true
-              (catch NoSuchKeyException _
-                false))))
+              (catch Exception e
+                (if (not-found? e) false (throw e))))))
 
 (defn list-objects
   "List ALL object keys in the bucket, following V2 continuation tokens.


### PR DESCRIPTION
## Symptom

With the released konserve-s3 (0.1.31) under datahike's virtual-thread IO path, `d/database-exists?` on a non-existent store — and a `k/get` of a missing key — **throws** instead of returning false/nil, on the **first** not-found of a fresh process:

```
Execution error (NoSuchKeyException) ... (Service: S3, Status Code: 404)
```

The konserve-s3 suite stayed green (it runs sync / on platform threads), so this only surfaced when a consumer (datahike's async writer) drove the ops on `io-try-` virtual threads.

## Root cause

The S3 SDK calls (`headObject`, `getObject`, `putObject`) resolve **reflectively** — `S3Client` is an interface and Clojure can't pick the overload for these request arg types (visible as `call to method getObject ... can't be resolved` under `*warn-on-reflection*`). A reflective invocation wraps a thrown `NoSuchKeyException` in `java.lang.reflect.InvocationTargetException`, so the bare `(catch NoSuchKeyException ...)` misses it. On the sync/platform-thread path the wrapper was unwrapped; on the virtual-thread path (first call) it wasn't — hence the thread- and warmup-dependent flakiness.

## Fix

A `not-found?` helper walks the exception **cause chain**, matching `NoSuchKeyException` anywhere in it (and a 404 `S3Exception`, which some S3-compatible servers return for HEAD, which has no error body). `exists?`, `get-object`, and `get-object-with-etag` now catch broadly and re-throw anything that is *not* a not-found — robust whether the SDK call is reflective or direct. The request args are also hinted to their concrete types (cosmetic; the catch is what makes it correct).

## Verification

Suite green vs MinIO (8 tests / 330 assertions / 0 failures). Verified end-to-end through datahike's tenant create/connect/transact on a **fresh process** (the failing first-call case).

## Follow-up (separate)

konserve-s3's S3 calls are pervasively reflective (`S3Client` interface; many `target class unknown` reflection warnings). Making them direct is worthwhile for throughput but independent of this correctness fix.