### PR TITLE
fix: pin konserve 0.9.354 (PReadMissSafe) + run MinIO tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,44 @@ version: 2.1
 orbs:
   tools: replikativ/clj-tools@0
 
+jobs:
+  # Cheap, always-on gate: load the namespace against the PINNED konserve, with no
+  # external service. A stale/incompatible konserve pin (e.g. one missing
+  # PReadMissSafe) fails here immediately — this is exactly the class of bug that
+  # shipped when the konserve 0.9.353 pin reached Clojars (the deploy built a
+  # source jar and unit tests were off, so nothing ever loaded the ns).
+  smoke:
+    docker:
+      - image: clojure:temurin-21-tools-deps
+    steps:
+      - checkout
+      - run:
+          name: load namespace against pinned konserve
+          command: clojure -M -e "(require 'konserve-s3.core)(println :loaded)"
+
+  # Integration tests against a MinIO service container. On the docker executor the
+  # secondary image is reachable on localhost, matching the tests' localhost:9000
+  # spec; the tests self-create the bucket (konserve-s3 -create-store).
+  unittest:
+    docker:
+      - image: clojure:temurin-21-tools-deps
+      - image: minio/minio:latest
+        environment:
+          MINIO_ROOT_USER: minioadmin
+          MINIO_ROOT_PASSWORD: minioadmin
+        command: server /data
+    steps:
+      - checkout
+      - run:
+          name: wait for MinIO on :9000
+          command: |
+            for i in $(seq 1 60); do (echo > /dev/tcp/localhost/9000) 2>/dev/null && exit 0; sleep 1; done
+            echo "MinIO did not come up on :9000"; exit 1
+      - run:
+          name: run tests against MinIO
+          command: |
+            clojure -M:test -e "(require '[clojure.test :as t] 'konserve-s3.core-test 'konserve-s3.minio-test)(let [{:keys [fail error]} (t/run-tests 'konserve-s3.core-test 'konserve-s3.minio-test)](when (or (pos? fail) (pos? error)) (System/exit 1)))"
+
 workflows:
   build-test-and-deploy:
     jobs:
@@ -18,10 +56,8 @@ workflows:
           context: docker-deploy
           requires:
             - tools/setup
-#      - tools/unittest:
-#          context: docker-deploy
-#          requires:
-#            - tools/build
+      - smoke
+      - unittest
       - tools/deploy:
           context:
             - clojars-deploy
@@ -32,7 +68,8 @@ workflows:
           requires:
             - tools/build
             - tools/format
-#            - tools/unittest
+            - smoke
+            - unittest
       - tools/release:
           context:
             - github-token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable, user-visible changes to konserve-s3 are documented here.
+
+## Unreleased
+
+### Added
+- **Read-miss-safe reads (single `GET`, no `HEAD`).** The S3 backing implements
+  konserve's `PReadMissSafe` and its `-read-header` throws
+  `store-key-not-found-ex` on an absent object. On a konserve that supports the
+  marker, a read is a single `GET` (the redundant `HEAD` existence probe is
+  dropped), and read-modify-write ops (`update-in` / `assoc-in` / `bassoc`) skip
+  the `HEAD` too — a hit goes from `HEAD` + `GET` + `PUT` to `GET` + `PUT`.
+  Requires konserve with `PReadMissSafe` (older konserve simply keeps the probe).
+- **`dissoc` with `:ignore-existence? true` skips the `HEAD`.** `DeleteObject` is
+  idempotent, so a caller that does not need the existed?/false-for-missing return
+  can delete in a single request. konserve-s3 is single-key, so konserve's GC
+  sweep takes this path — each dead-object delete is one `DELETE` instead of
+  `HEAD` + `DELETE`. The default `dissoc` still probes to honour the contract.

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps {org.replikativ/logging {:mvn/version "0.1.3"}
-        org.replikativ/konserve {:mvn/version "0.9.353"}
+        org.replikativ/konserve {:mvn/version "0.9.354"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
         org.clojure/clojure {:mvn/version "1.10.3"}
 

--- a/src/konserve_s3/core.clj
+++ b/src/konserve_s3/core.clj
@@ -692,14 +692,20 @@
         suffix-len (count marker-suffix)]
     (async+sync (:sync? complete-opts) io-sync-translation
                 (io-try-
-                 (->> (list-objects client bucket)
-                      (keep (fn [^String k]
-                              (when (.endsWith k marker-suffix)
-                                (try
-                                  (UUID/fromString
-                                   (subs k 0 (- (count k) suffix-len)))
-                                  (catch IllegalArgumentException _ nil)))))
-                      set)))))
+                 ;; A non-existent bucket trivially holds no stores. list-objects
+                 ;; throws NoSuchBucket (a 404) there; treat it as the empty set so
+                 ;; list-stores is safe to call before any store/bucket exists.
+                 (try
+                   (->> (list-objects client bucket)
+                        (keep (fn [^String k]
+                                (when (.endsWith k marker-suffix)
+                                  (try
+                                    (UUID/fromString
+                                     (subs k 0 (- (count k) suffix-len)))
+                                    (catch IllegalArgumentException _ nil)))))
+                        set)
+                   (catch Exception e
+                     (if (not-found? e) #{} (throw e))))))))
 
 (comment
 

--- a/test/konserve_s3/minio_test.clj
+++ b/test/konserve_s3/minio_test.clj
@@ -47,6 +47,57 @@
       (<!! (store/release-store spec s {:sync? false}))
       (<!! (store/delete-store spec {:sync? false})))))
 
+(def round-trip-store-id #uuid "77777777-7777-7777-7777-777777777777")
+
+(deftest minio-round-trip-count-test
+  (testing "PReadMissSafe: no HEAD probe on read / update-in / dissoc / bassoc (real S3 op counts)"
+    (let [spec (assoc minio-spec :backend :s3 :id round-trip-store-id)
+          _    (store/delete-store spec {:sync? true})
+          s    (store/create-store spec {:sync? true})
+          heads   (fn [r] (get-in r [:stats :head :n] 0))
+          gets    (fn [r] (get-in r [:stats :get :n] 0))]
+      (try
+        (k/assoc s :k {:v 1} {:sync? true})
+
+        (testing "get hit: exactly one GET, no HEAD"
+          (let [r (s3/with-io-stats (k/get s :k nil {:sync? true}))]
+            (is (= {:v 1} (:result r)))
+            (is (= 0 (heads r)) "no HEAD probe")
+            (is (= 1 (gets r)) "exactly one GET")))
+
+        (testing "get miss: no HEAD (read-first reports the miss)"
+          (let [r (s3/with-io-stats (k/get s :missing nil {:sync? true}))]
+            (is (nil? (:result r)))
+            (is (= 0 (heads r)) "no HEAD probe")))
+
+        (testing "update-in (read-modify-write): no HEAD"
+          (let [r (s3/with-io-stats (k/update-in s [:k :v] inc {:sync? true}))]
+            (is (= 0 (heads r)) "no HEAD probe")
+            (is (= {:v 2} (k/get s :k nil {:sync? true})))))
+
+        (testing "bassoc (binary write): no HEAD"
+          (let [r (s3/with-io-stats (k/bassoc s :b (.getBytes "hello") {:sync? true}))]
+            (is (= 0 (heads r)) "no HEAD probe")))
+
+        ;; dissoc keeps its HEAD by default — konserve's contract requires it to
+        ;; report existed?/false-for-missing, which S3 DELETE cannot.
+        (testing "dissoc (default): one HEAD (existed? contract) + one DELETE"
+          (let [r (s3/with-io-stats (k/dissoc s :k {:sync? true}))]
+            (is (= 1 (heads r)) "one HEAD probe (contract)")
+            (is (pos? (get-in r [:stats :delete :n] 0)) "one DELETE")
+            (is (nil? (k/get s :k nil {:sync? true})) "key is gone")))
+
+        ;; ...but a caller that doesn't need the boolean opts out of the HEAD.
+        (testing "dissoc with :ignore-existence? true: no HEAD, one DELETE (GC fast path)"
+          (k/assoc s :k2 {:v 1} {:sync? true})
+          (let [r (s3/with-io-stats (k/dissoc s :k2 {:sync? true :ignore-existence? true}))]
+            (is (= 0 (heads r)) "no HEAD probe")
+            (is (pos? (get-in r [:stats :delete :n] 0)) "one DELETE")
+            (is (nil? (k/get s :k2 nil {:sync? true})) "key is gone")))
+        (finally
+          (store/release-store spec s {:sync? true})
+          (store/delete-store spec {:sync? true}))))))
+
 (deftest minio-store-exists-test
   (testing "store-exists? with marker file"
     (let [spec (assoc minio-spec :backend :s3 :id exists-store-id)]


### PR DESCRIPTION
Fixes the broken transitive konserve pin from #10 (0.9.353 lacks `PReadMissSafe`, so `konserve-s3.core` fails to load) and closes the CI gap that let it ship. Adds a **smoke** job (loads the ns against the pinned konserve — no service, catches stale pins) and a **unittest** job (MinIO service container on `localhost:9000`; tests self-create the bucket); deploy now requires both. Also lands the real-S3 op-count assertions. Verified locally: loads against 0.9.354, 9 tests / 344 assertions / 0 failures vs MinIO.