### PR TITLE
fix(delete-store): await the deletion — the async path was a silent no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,15 @@ All notable, user-visible changes to konserve-s3 are documented here.
   can delete in a single request. konserve-s3 is single-key, so konserve's GC
   sweep takes this path — each dead-object delete is one `DELETE` instead of
   `HEAD` + `DELETE`. The default `dissoc` still probes to honour the contract.
+
+### Fixed
+- **`delete-store` deleted nothing on the async path.** `-delete-store :s3` returned
+  its inner `delete-store` call *without awaiting it*, so under `{:sync? false}` —
+  which is `konserve.store/delete-store`'s **default**, and what Datahike's
+  `d/delete-database` uses — the caller got back an un-awaited channel, the objects
+  were never removed, `store-exists?` kept returning `true`, and any error was
+  swallowed into a channel nobody read. The three sibling methods (`-connect-store`,
+  `-create-store`, `-store-exists?`) all await their inner call; this one did not.
+  Deleting a store (offboarding a tenant, GDPR erasure) was silently a no-op on S3.
+  Every existing `delete-store` test passed `{:sync? true}`, which is why it went
+  unnoticed — the regression test added here is deliberately async.

--- a/src/konserve_s3/core.clj
+++ b/src/konserve_s3/core.clj
@@ -839,7 +839,14 @@
   (async+sync (:sync? opts) *default-sync-translation*
               (go-try-
                (let [s3-spec (dissoc config :backend)]
-                 (delete-store s3-spec :opts opts)))))
+                 ;; `delete-store` returns a CHANNEL under {:sync? false} (the default
+                 ;; konserve.store/delete-store passes, and what datahike's
+                 ;; d/delete-database uses). Awaiting it is not optional: without the
+                 ;; <?- this go-try- yields the un-awaited channel as its value, so the
+                 ;; caller sees "done" while nothing has been deleted, and any error is
+                 ;; swallowed into a channel nobody reads. The sibling methods above all
+                 ;; await; this one did not.
+                 (<?- (delete-store s3-spec :opts opts))))))
 
 (defmethod store/-release-store :s3
   [_config store opts]

--- a/test/konserve_s3/minio_test.clj
+++ b/test/konserve_s3/minio_test.clj
@@ -120,6 +120,30 @@
         (store/delete-store spec {:sync? true})
         (is (false? (store/store-exists? spec {:sync? true})))))))
 
+(def async-delete-store-id #uuid "77777777-7777-7777-7777-777777777777")
+
+(deftest minio-async-delete-store-test
+  (testing "delete-store on the ASYNC path actually deletes (and reports completion)"
+    ;; Regression: `-delete-store :s3` returned its inner channel WITHOUT awaiting it,
+    ;; so under {:sync? false} — konserve.store/delete-store's DEFAULT, and what
+    ;; datahike's d/delete-database uses — the caller was handed an un-awaited channel,
+    ;; nothing was deleted, and any error was swallowed into a channel nobody read.
+    ;; Every existing delete-store test passed {:sync? true}, so the async path (the
+    ;; one real callers take) was never exercised. Keep this one async.
+    (let [spec (assoc minio-spec :backend :s3 :id async-delete-store-id)]
+      (try (store/delete-store spec {:sync? true}) (catch Exception _))
+
+      (let [s (store/create-store spec {:sync? true})]
+        (k/assoc-in s [:k] "v" {:sync? true})
+        (is (true? (store/store-exists? spec {:sync? true})))
+        (store/release-store spec s {:sync? true}))
+
+      ;; The default opts are {:sync? false}: take from the channel and assert the
+      ;; store is gone by the time it delivers.
+      (<!! (store/delete-store spec))
+      (is (false? (store/store-exists? spec {:sync? true}))
+          "async delete-store must have removed the store by the time its channel delivers"))))
+
 (deftest minio-multi-store-test
   (testing "multiple stores in same bucket with different IDs"
     (let [spec1 (assoc minio-spec :backend :s3 :id store1-id)


### PR DESCRIPTION
## The bug

`-delete-store :s3` returned its inner `delete-store` call **without awaiting it**:

```clojure
(defmethod store/-delete-store :s3
  [{:keys [region bucket id] :as config} opts]
  (async+sync (:sync? opts) *default-sync-translation*
              (go-try-
               (let [s3-spec (dissoc config :backend)]
                 (delete-store s3-spec :opts opts)))))   ;; <- returns a CHANNEL
```

Under `{:sync? false}` — which is `konserve.store/delete-store`'s **default**, and what Datahike's `d/delete-database` passes — the inner `delete-store` returns a channel, so the enclosing `go-try-` yields *that channel* as its value. The caller sees a completed operation while nothing has been deleted, and any error is swallowed into a channel nobody reads.

**Observed on S3/MinIO:** `d/delete-database` left every object in the bucket, `store-exists?` kept returning `true` afterwards, and delete-then-recreate raced. Deleting a store — offboarding a customer, GDPR erasure — silently did not happen.

The three sibling methods (`-connect-store`, `-create-store`, `-store-exists?`) all wrap their inner call in `<?-`. This one didn't.

## The fix

One `<?-`, plus a comment explaining why it isn't optional.

## Why the tests missed it

Every existing `delete-store` assertion passes `{:sync? true}`, which collapses `go-try-` → `try` and makes `delete-store` a direct call — so the missing await is invisible on that path. The async path (the one real callers take) was never exercised.

The regression test added here is deliberately async: it takes from the channel and asserts the store is gone by the time it delivers. **It fails without the fix and passes with it.**

## Verification

- New test `minio-async-delete-store-test`: fails on `main`, passes with the fix.
- Full suite against MinIO: **10 tests, 346 assertions, 0 failures.**
- End-to-end: with this fix, `d/delete-database` on an S3 store actually removes the objects (previously it did not, at all).

Found while implementing per-tenant delete/export in a db-per-tenant SaaS template, where `d/delete-database` on S3 appeared to succeed and left the tenant fully intact.