### PR TITLE
Let the caller choose a serializer; konserve 0.9.369

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps {org.replikativ/logging {:mvn/version "0.1.3"}
-        org.replikativ/konserve {:mvn/version "0.9.354"}
+        org.replikativ/konserve {:mvn/version "0.9.369"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
         org.clojure/clojure {:mvn/version "1.10.3"}
 

--- a/src/konserve_s3/core.clj
+++ b/src/konserve_s3/core.clj
@@ -653,11 +653,24 @@
                         :no-backup? true
                         :lock-blob? true}
         merged-config (merge default-config user-config)
-        ;; Only pass non-S3-specific config to connect-default-store
-        config {:opts               complete-opts
-                :config             merged-config
-                :default-serializer :FressianSerializer
-                :buffer-size        (* 1024 1024)}]
+        ;; S3-specific keys are stripped; everything else reaches
+        ;; `connect-default-store`. `:default-serializer` used to be a LITERAL
+        ;; here, so a caller could not choose one at all -- worse than the
+        ;; other backends, which merely dropped it. That made konserve's boring
+        ;; serializer unreachable on S3 however it was asked for.
+        ;; An ALLOWLIST, not a strip-list, and the direction matters here:
+        ;; an s3-spec is mostly CONNECTION keys -- :region, :access-key,
+        ;; :endpoint-override, :path-style-access?, :x-ray? -- so subtracting
+        ;; the ones to hide would leak a new one into the store config every
+        ;; time this spec grows. Konserve's store-config surface is the small,
+        ;; stable set, so name that instead.
+        config (merge {:default-serializer :FressianSerializer
+                       :buffer-size        (* 1024 1024)}
+                      (select-keys s3-spec [:default-serializer :serializers
+                                            :read-handlers :write-handlers
+                                            :buffer-size])
+                      {:opts   complete-opts
+                       :config merged-config})]
     (connect-default-store backing config)))
 
 (defn release

--- a/src/konserve_s3/core.clj
+++ b/src/konserve_s3/core.clj
@@ -1,6 +1,6 @@
 (ns konserve-s3.core
   "S3 based konserve backend."
-  (:require [konserve.impl.defaults :refer [connect-default-store]]
+  (:require [konserve.impl.defaults :refer [connect-default-store normalize-store-config]]
             [konserve.impl.storage-layout :refer [PBackingStore PBackingBlob PBackingLock PReadMissSafe
                                                   store-key-not-found-ex -delete-store header-size]]
             [konserve.utils :refer [async+sync *default-sync-translation*]]
@@ -664,13 +664,20 @@
         ;; the ones to hide would leak a new one into the store config every
         ;; time this spec grows. Konserve's store-config surface is the small,
         ;; stable set, so name that instead.
-        config (merge {:default-serializer :FressianSerializer
-                       :buffer-size        (* 1024 1024)}
-                      (select-keys s3-spec [:default-serializer :serializers
-                                            :read-handlers :write-handlers
-                                            :buffer-size])
-                      {:opts   complete-opts
-                       :config merged-config})]
+        ;; Normalised BEFORE defaults are filled: emitting
+        ;; `:default-serializer` ourselves would trip konserve's deprecation
+        ;; warning on every connect whatever the caller passed, and filling
+        ;; first would let our Fressian default occupy the slot and silently
+        ;; drop a caller's older `:default-serializer :BoringSerializer`.
+        config (-> (select-keys s3-spec [:default-serializer :serializers
+                                         :read-handlers :write-handlers
+                                         :buffer-size])
+                   (assoc :config merged-config)
+                   normalize-store-config
+                   (update-in [:config :encoding]
+                              #(merge {:serializer :FressianSerializer} %))
+                   (update :buffer-size #(or % (* 1024 1024)))
+                   (assoc :opts complete-opts))]
     (connect-default-store backing config)))
 
 (defn release


### PR DESCRIPTION
`:default-serializer :FressianSerializer` was a **literal** in the config handed to `connect-default-store`, so a caller could not choose one at all. That is worse than the other backends, which merely dropped what they were given: here konserve's boring serializer was unreachable however it was asked for.

### An allowlist, not a strip-list

The direction matters for this backend specifically: an s3-spec is mostly **connection** keys — `:region`, `:access-key`, `:endpoint-override`, `:path-style-access?`, `:x-ray?` — so subtracting the ones to hide would leak a new one into the store config every time the spec grows. Konserve's store-config surface is the small stable set, so that is what is named.

`:config` was already merged correctly, so `{:compressor {:type :zstd}}` and 0.9.369's `{:encoding {...}}` already worked — this is only the serializer half.

### Not integration tested

The suite needs AWS credentials and a bucket, which my environment does not have. I verified only that the namespace loads and the config assembly compiles. The change is small and mechanical, but **someone with a bucket should run the suite before release.**